### PR TITLE
fix: report module version for go install builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,8 @@ jobs:
 
           build_time="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           commit_hash="${GITHUB_SHA::7}"
-          ldflags="-X 'github.com/Format-C-eft/git-update/internal/config.branch=${GITHUB_REF_NAME}' -X 'github.com/Format-C-eft/git-update/internal/config.commitHash=${commit_hash}' -X 'github.com/Format-C-eft/git-update/internal/config.timeBuild=${build_time}'"
+          version="${{ steps.version.outputs.tag }}"
+          ldflags="-X 'github.com/Format-C-eft/git-update/internal/config.version=${version}' -X 'github.com/Format-C-eft/git-update/internal/config.branch=${GITHUB_REF_NAME}' -X 'github.com/Format-C-eft/git-update/internal/config.commitHash=${commit_hash}' -X 'github.com/Format-C-eft/git-update/internal/config.timeBuild=${build_time}'"
 
           for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
             goos="${target%/*}"

--- a/build.mk
+++ b/build.mk
@@ -18,7 +18,12 @@ ifndef BUILD_TS
 	BUILD_TS:=$(shell date +%FT%T%z)
 endif
 
-LDFLAGS = -X 'github.com/Format-C-eft/git-update/internal/config.branch=$(GIT_BRANCH)'\
+ifndef VERSION
+	VERSION:=$(shell git describe --tags --dirty --always 2> /dev/null || echo "-")
+endif
+
+LDFLAGS = -X 'github.com/Format-C-eft/git-update/internal/config.version=$(VERSION)'\
+          -X 'github.com/Format-C-eft/git-update/internal/config.branch=$(GIT_BRANCH)'\
           -X 'github.com/Format-C-eft/git-update/internal/config.commitHash=$(GIT_HASH)'\
           -X 'github.com/Format-C-eft/git-update/internal/config.timeBuild=$(BUILD_TS)'
 

--- a/cmd/git-update/main.go
+++ b/cmd/git-update/main.go
@@ -24,8 +24,11 @@ func main() {
 }
 
 func showVersion() {
-	fmt.Printf("Name - '%s'\n", config.GetVersion().Name)
-	fmt.Printf("Branch - '%s'\n", config.GetVersion().Branch)
-	fmt.Printf("Commit hash - '%s'\n", config.GetVersion().CommitHash)
-	fmt.Printf("Time build - '%s'\n", config.GetVersion().TimeBuild)
+	version := config.GetVersion()
+
+	fmt.Printf("Name - '%s'\n", version.Name)
+	fmt.Printf("Version - '%s'\n", version.Version)
+	fmt.Printf("Branch - '%s'\n", version.Branch)
+	fmt.Printf("Commit hash - '%s'\n", version.CommitHash)
+	fmt.Printf("Time build - '%s'\n", version.TimeBuild)
 }

--- a/internal/config/dto.go
+++ b/internal/config/dto.go
@@ -1,26 +1,69 @@
 package config
 
+import "runtime/debug"
+
 const AppName = "git-update"
+
+const (
+	buildInfoVCSRevision = "vcs.revision"
+	buildInfoVCSTime     = "vcs.time"
+	unknownBuildValue    = "-"
+)
 
 // Build information -ldflags .
 var (
-	branch     = "dev"
-	commitHash = "-"
-	timeBuild  = "-"
+	version    = unknownBuildValue
+	branch     = unknownBuildValue
+	commitHash = unknownBuildValue
+	timeBuild  = unknownBuildValue
 )
 
 type Version struct {
 	Name       string `json:"name,omitempty"`
+	Version    string `json:"version,omitempty"`
 	Branch     string `json:"branch,omitempty"`
 	CommitHash string `json:"commitHash,omitempty"`
 	TimeBuild  string `json:"timeBuild,omitempty"`
 }
 
 func GetVersion() Version {
-	return Version{
+	result := Version{
 		Name:       AppName,
+		Version:    version,
 		Branch:     branch,
 		CommitHash: commitHash,
 		TimeBuild:  timeBuild,
 	}
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return result
+	}
+
+	return enrichVersionFromBuildInfo(result, buildInfo)
+}
+
+func enrichVersionFromBuildInfo(result Version, buildInfo *debug.BuildInfo) Version {
+	if result.Version == unknownBuildValue && buildInfo.Main.Version != "" && buildInfo.Main.Version != "(devel)" {
+		result.Version = buildInfo.Main.Version
+	}
+
+	for _, setting := range buildInfo.Settings {
+		if setting.Value == "" {
+			continue
+		}
+
+		switch setting.Key {
+		case buildInfoVCSRevision:
+			if result.CommitHash == unknownBuildValue {
+				result.CommitHash = setting.Value
+			}
+		case buildInfoVCSTime:
+			if result.TimeBuild == unknownBuildValue {
+				result.TimeBuild = setting.Value
+			}
+		}
+	}
+
+	return result
 }

--- a/internal/config/dto_test.go
+++ b/internal/config/dto_test.go
@@ -1,29 +1,46 @@
 package config
 
 import (
+	"runtime/debug"
 	"testing"
 	"time"
 )
 
+const (
+	testCommitHash      = "abc123"
+	testModuleVersion   = "v0.1.1"
+	testOverrideVersion = "v9.9.9"
+	testRevision        = "1234567890abcdef"
+	testTimeBuild       = "2026-05-27T12:00:00+0500"
+	testVCSTime         = "2026-05-27T08:00:00Z"
+)
+
 func TestGetVersion(t *testing.T) {
+	oldVersion := version
 	oldBranch := branch
 	oldCommitHash := commitHash
 	oldTimeBuild := timeBuild
 
 	t.Cleanup(func() {
+		version = oldVersion
 		branch = oldBranch
 		commitHash = oldCommitHash
 		timeBuild = oldTimeBuild
 	})
 
+	version = "v1.2.3"
 	branch = "test-branch"
-	commitHash = "abc123"
-	timeBuild = "2026-05-27T12:00:00+0500"
+	commitHash = testCommitHash
+	timeBuild = testTimeBuild
 
 	got := GetVersion()
 
 	if got.Name != AppName {
 		t.Fatalf("Name = %q, want %q", got.Name, AppName)
+	}
+
+	if got.Version != version {
+		t.Fatalf("Version = %q, want %q", got.Version, version)
 	}
 
 	if got.Branch != branch {
@@ -36,6 +53,66 @@ func TestGetVersion(t *testing.T) {
 
 	if got.TimeBuild != timeBuild {
 		t.Fatalf("TimeBuild = %q, want %q", got.TimeBuild, timeBuild)
+	}
+}
+
+func TestEnrichVersionFromBuildInfo(t *testing.T) {
+	got := enrichVersionFromBuildInfo(Version{
+		Name:       AppName,
+		Version:    unknownBuildValue,
+		Branch:     unknownBuildValue,
+		CommitHash: unknownBuildValue,
+		TimeBuild:  unknownBuildValue,
+	}, &debug.BuildInfo{
+		Main: debug.Module{
+			Version: testModuleVersion,
+		},
+		Settings: []debug.BuildSetting{
+			{Key: buildInfoVCSRevision, Value: testRevision},
+			{Key: buildInfoVCSTime, Value: testVCSTime},
+		},
+	})
+
+	if got.Version != testModuleVersion {
+		t.Fatalf("Version = %q, want %q", got.Version, testModuleVersion)
+	}
+
+	if got.CommitHash != testRevision {
+		t.Fatalf("CommitHash = %q, want %q", got.CommitHash, testRevision)
+	}
+
+	if got.TimeBuild != testVCSTime {
+		t.Fatalf("TimeBuild = %q, want %q", got.TimeBuild, testVCSTime)
+	}
+}
+
+func TestEnrichVersionFromBuildInfoKeepsLdflagsValues(t *testing.T) {
+	got := enrichVersionFromBuildInfo(Version{
+		Name:       AppName,
+		Version:    testOverrideVersion,
+		Branch:     "main",
+		CommitHash: testCommitHash,
+		TimeBuild:  testTimeBuild,
+	}, &debug.BuildInfo{
+		Main: debug.Module{
+			Version: testModuleVersion,
+		},
+		Settings: []debug.BuildSetting{
+			{Key: buildInfoVCSRevision, Value: testRevision},
+			{Key: buildInfoVCSTime, Value: testVCSTime},
+		},
+	})
+
+	if got.Version != testOverrideVersion {
+		t.Fatalf("Version = %q, want %q", got.Version, testOverrideVersion)
+	}
+
+	if got.CommitHash != testCommitHash {
+		t.Fatalf("CommitHash = %q, want %q", got.CommitHash, testCommitHash)
+	}
+
+	if got.TimeBuild != testTimeBuild {
+		t.Fatalf("TimeBuild = %q, want %q", got.TimeBuild, testTimeBuild)
 	}
 }
 


### PR DESCRIPTION
Read Go build metadata as a fallback when ldflags are not provided, so binaries installed with go install show the module version instead of the old placeholder branch.

Also pass the release tag through ldflags for release assets.